### PR TITLE
Support the full spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-jsonrpc/test/test
-**test.dSYM**
+/build/
+/.deps/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+PACKAGE_DIR=jsonrpc
+PONYC ?= ponyc
+config ?= debug
+ifdef config
+  ifeq (,$(filter $(config),debug release))
+    $(error Unknown configuration "$(config)")
+  endif
+endif
+
+ifeq ($(config),debug)
+	PONYC_FLAGS += --debug
+endif
+
+PONYC_FLAGS += -o build/$(config)
+
+
+ALL: test
+
+build/$(config)/test: .deps $(PACKAGE_DIR)/*.pony $(PACKAGE_DIR)/test/*.pony | build/$(config)
+	stable env $(PONYC) ${PONYC_FLAGS} $(PACKAGE_DIR)/test
+
+build/$(config):
+	mkdir -p build/$(config)
+
+.deps:
+	stable fetch
+
+test: build/$(config)/test
+	build/$(config)/test
+
+clean:
+	rm -rf build
+
+.PHONY: clean test

--- a/bundle.json
+++ b/bundle.json
@@ -1,0 +1,8 @@
+{
+  "deps": [
+    {
+      "type": "github",
+      "repo": "mfelsche/pony-immutable-json"
+    }
+  ]
+}

--- a/jsonrpc/batch_request.pony
+++ b/jsonrpc/batch_request.pony
@@ -1,0 +1,9 @@
+
+class val BatchRequest
+  let requests: Array[(Request val | ParseError)] val
+
+  new val create(requests': Array[(Request val | ParseError)] val) =>
+    requests = requests'
+
+  fun box size(): USize => requests.size()
+  fun box apply(i: USize): (Request val | ParseError) ? => requests(i)?

--- a/jsonrpc/batch_request.pony
+++ b/jsonrpc/batch_request.pony
@@ -1,9 +1,33 @@
+use "immutable-json"
 
 class val BatchRequest
-  let requests: Array[(Request val | ParseError)] val
+  let requests: Array[(Request | ParseError)] val
 
-  new val create(requests': Array[(Request val | ParseError)] val) =>
+  new val create(requests': Array[(Request | ParseError)] val) =>
     requests = requests'
 
   fun box size(): USize => requests.size()
-  fun box apply(i: USize): (Request val | ParseError) ? => requests(i)?
+  fun box apply(i: USize): (Request | ParseError) ? => requests(i)?
+
+  fun box to_json(): String =>
+    let s = recover trn String() end
+
+    s.append("[")
+    let iter = requests.values()
+    while iter.has_next() do
+      let r = try iter.next()? else "\"ERROR\"" end
+      s.append(
+        match r
+        | let req: Request => req.to_json()
+        | let _: InvalidJson    => "{\"error\": \"INVALID JSON\"}"
+        | let _: InvalidRequest => "{\"error\": \"INVALID REQUEST\"}"
+        else
+          "WEIRD!"
+        end)
+      if iter.has_next() then
+        s.append(", ")
+      end
+    end
+    s.append("]")
+
+    consume s

--- a/jsonrpc/dispatcher.pony
+++ b/jsonrpc/dispatcher.pony
@@ -10,6 +10,11 @@ actor Dispatcher
   be register_handler(method: String, handler: MethodHandler tag) =>
     _methods(method) = handler
 
+  fun tag apply(request: Request val): Promise[Response val] =>
+    let promise = Promise[Response val]()
+    dispatch_request(request, promise)
+    promise
+
   be dispatch_request(request: Request val, p: Promise[Response val]) =>
     try
       _methods(request.method)?.handle(request, p)

--- a/jsonrpc/dispatcher.pony
+++ b/jsonrpc/dispatcher.pony
@@ -11,7 +11,7 @@ actor Dispatcher
     _methods(method) = handler
 
   fun tag apply(request: Request val): Promise[Response val] =>
-    let promise = Promise[Response val]()
+    let promise = Promise[Response val]
     dispatch_request(request, promise)
     promise
 

--- a/jsonrpc/dispatcher.pony
+++ b/jsonrpc/dispatcher.pony
@@ -8,11 +8,11 @@ actor Dispatcher
     _methods = Map[String, MethodHandler tag]
 
   be register_handler(method: String, handler: MethodHandler tag) =>
-    _methods(method) = handler 
+    _methods(method) = handler
 
   be dispatch_request(request: Request val, p: Promise[Response val]) =>
-    try     
+    try
       _methods(request.method)?.handle(request, p)
     else
       p.reject()
-    end 
+    end

--- a/jsonrpc/error.pony
+++ b/jsonrpc/error.pony
@@ -1,4 +1,5 @@
-use "json"
+use "immutable-json"
+use "collections"
 
 primitive ErrorCodes
   fun parse(): I64 => -32700
@@ -13,7 +14,7 @@ class val Error
   let message: String
   let data: JsonType
 
-  new val create(code': I64, message': String, data': JsonType val) =>
+  new val create(code': I64, message': String, data': JsonType) =>
     code = code'
     message = message'
     data = data'
@@ -44,10 +45,10 @@ class val Error
     data = None
 
   fun to_jsonobject(): JsonObject =>
-    let ob: JsonObject = JsonObject
-    ob.data("code") = code
-    ob.data("message") = message
-    if data isnt None
-      ob.data("data") = JsonCopy(data)
+    let json_obj = recover trn Map[String, JsonType] end
+    json_obj("code") = code
+    json_obj("message") = message
+    if data isnt None then
+      json_obj("data") = data
     end
-    ob
+    JsonObject(consume json_obj)

--- a/jsonrpc/error.pony
+++ b/jsonrpc/error.pony
@@ -8,22 +8,46 @@ primitive ErrorCodes
   fun internal_error(): I64 => -32603
   fun server_error(): I64 => -32000 // range -32000 to -32099
 
-class Error
-  let code: I64 
+class val Error
+  let code: I64
   let message: String
-  let data: JsonType 
+  let data: JsonType
 
-  new create(code': I64, message': String, data': JsonType) =>
+  new val create(code': I64, message': String, data': JsonType val) =>
     code = code'
     message = message'
     data = data'
+
+  new val method_not_found(method: ( String | None ) = None) =>
+    code = ErrorCodes.method_not_found()
+    message = "Method not found"
+    data = method
+
+  new val parse_error() =>
+    code = ErrorCodes.parse()
+    message = "Parse Error"
+    data = None
+
+  new val invalid_request() =>
+    code = ErrorCodes.invalid_request()
+    message = "Invalid Request"
+    data = None
+
+  new val invalid_params() =>
+    code = ErrorCodes.invalid_params()
+    message = "Invalid params"
+    data = None
+
+  new val internal_error() =>
+    code = ErrorCodes.internal_error()
+    message = "Inernal error"
+    data = None
 
   fun to_jsonobject(): JsonObject =>
     let ob: JsonObject = JsonObject
     ob.data("code") = code
     ob.data("message") = message
-    // TODO - figure out how to add this back in later.
-    //if data isnt None then       
-    //  ob.data("data") = data 
-    //end
-    ob 
+    if data isnt None
+      ob.data("data") = JsonCopy(data)
+    end
+    ob

--- a/jsonrpc/protocol.pony
+++ b/jsonrpc/protocol.pony
@@ -1,0 +1,2 @@
+primitive Protocol
+  fun tag version(): String => "2.0"

--- a/jsonrpc/request.pony
+++ b/jsonrpc/request.pony
@@ -1,16 +1,84 @@
 use "json"
+use "collections"
 
 type RequestIDType is (String | I64 | None)
+type RequestParamsType is ( JsonArray val | JsonObject val | None)
 
-class val Request  
+class val Request
   let method : String
-  let params : JsonType val
+  let params : RequestParamsType
   let id : RequestIDType
 
-  new val create(method': String, params': JsonType val, id': RequestIDType) =>
+  new val create(method': String, params': RequestParamsType, id': RequestIDType) =>
     method = method'
     params = params'
     id = id'
 
-  fun is_notification() =>
-    id is None 
+  fun is_notification(): Bool =>
+    id is None
+
+  fun box to_json(): String =>
+    let doc:JsonDoc = JsonDoc
+
+    var dmap: Map[String, JsonType] = Map[String, JsonType]
+    dmap("jsonrpc") = Protocol.version()
+    // id SHOULD NOT be Null
+    if id isnt None then
+      dmap("id") = id
+    end
+    dmap("method") = method
+    match params
+    | let arr: JsonArray val =>
+      dmap("params") = JsonCopy(arr)
+    | let obj: JsonObject val =>
+      dmap("params") = JsonCopy(obj)
+    end
+
+    let obj: JsonObject = JsonObject.from_map(dmap)
+    doc.data = obj
+    doc.string()
+
+primitive JsonCopy
+
+  fun apply(imm: JsonType val): JsonType =>
+    match imm
+    | let arr: JsonArray val => _arr(arr)
+    | let obj: JsonObject val => _obj(obj)
+    | let f: F64 => f
+    | let i: I64 => i
+    | let b: Bool => b
+    | let s: String => s
+    | None => None
+    end
+
+  fun tag _arr(imm: JsonArray val): JsonArray =>
+    let tmp = JsonArray(imm.data.size())
+    for imm_elem in imm.data.values() do
+      tmp.data.push(
+        match imm_elem
+        | let arr_elem: JsonArray val  => _arr(arr_elem)
+        | let obj_elem: JsonObject val => _obj(obj_elem)
+        | let f: F64 => f
+        | let i: I64 => i
+        | let b: Bool => b
+        | let s: String => s
+        | None => None
+        end)
+    end
+    tmp
+
+  fun tag _obj(imm: JsonObject val): JsonObject =>
+    let tmp = JsonObject(imm.data.size())
+    for kv in imm.data.pairs() do
+      tmp.data(kv._1) =
+        match kv._2
+        | let arr_value: JsonArray val  => _arr(arr_value)
+        | let obj_value: JsonObject val => _obj(obj_value)
+        | let f: F64 => f
+        | let i: I64 => i
+        | let b: Bool => b
+        | let s: String => s
+        | None => None
+        end
+    end
+    tmp

--- a/jsonrpc/request.pony
+++ b/jsonrpc/request.pony
@@ -1,8 +1,8 @@
-use "json"
+use "immutable-json"
 use "collections"
 
 type RequestIDType is (String | I64 | None)
-type RequestParamsType is ( JsonArray val | JsonObject val | None)
+type RequestParamsType is ( JsonArray | JsonObject | None)
 
 class val Request
   let method : String
@@ -18,67 +18,19 @@ class val Request
     id is None
 
   fun box to_json(): String =>
-    let doc:JsonDoc = JsonDoc
+    let doc: JsonDoc = JsonDoc
 
-    var dmap: Map[String, JsonType] = Map[String, JsonType]
+    var dmap: Map[String, JsonType] trn = recover Map[String, JsonType] end
     dmap("jsonrpc") = Protocol.version()
+
     // id SHOULD NOT be Null
     if id isnt None then
       dmap("id") = id
     end
     dmap("method") = method
-    match params
-    | let arr: JsonArray val =>
-      dmap("params") = JsonCopy(arr)
-    | let obj: JsonObject val =>
-      dmap("params") = JsonCopy(obj)
-    end
+    dmap("params") = params
 
-    let obj: JsonObject = JsonObject.from_map(dmap)
+    let obj: JsonObject = JsonObject(consume dmap)
     doc.data = obj
     doc.string()
 
-primitive JsonCopy
-
-  fun apply(imm: JsonType val): JsonType =>
-    match imm
-    | let arr: JsonArray val => _arr(arr)
-    | let obj: JsonObject val => _obj(obj)
-    | let f: F64 => f
-    | let i: I64 => i
-    | let b: Bool => b
-    | let s: String => s
-    | None => None
-    end
-
-  fun tag _arr(imm: JsonArray val): JsonArray =>
-    let tmp = JsonArray(imm.data.size())
-    for imm_elem in imm.data.values() do
-      tmp.data.push(
-        match imm_elem
-        | let arr_elem: JsonArray val  => _arr(arr_elem)
-        | let obj_elem: JsonObject val => _obj(obj_elem)
-        | let f: F64 => f
-        | let i: I64 => i
-        | let b: Bool => b
-        | let s: String => s
-        | None => None
-        end)
-    end
-    tmp
-
-  fun tag _obj(imm: JsonObject val): JsonObject =>
-    let tmp = JsonObject(imm.data.size())
-    for kv in imm.data.pairs() do
-      tmp.data(kv._1) =
-        match kv._2
-        | let arr_value: JsonArray val  => _arr(arr_value)
-        | let obj_value: JsonObject val => _obj(obj_value)
-        | let f: F64 => f
-        | let i: I64 => i
-        | let b: Bool => b
-        | let s: String => s
-        | None => None
-        end
-    end
-    tmp

--- a/jsonrpc/request_parser.pony
+++ b/jsonrpc/request_parser.pony
@@ -4,14 +4,13 @@ primitive InvalidJson
 primitive InvalidRequest
 
 type ParseError is (InvalidJson | InvalidRequest )
-type BatchRequest is Array[(Request val | ParseError)] val
-type ParseResult is (BatchRequest | Request val | ParseError)
+type ParseResult is (BatchRequest | Request | ParseError)
 
 primitive RequestParser
 
   fun tag _parse_batch_request(arr: JsonArray): BatchRequest =>
     let s = arr.data.size()
-    let results = recover iso Array[(Request val | ParseError)](s) end
+    let results = recover trn Array[(Request | ParseError)](s) end
     for elem in arr.data.values() do
       results.push(
         match elem
@@ -21,9 +20,9 @@ primitive RequestParser
         end
       )
     end
-    results
+    BatchRequest(consume results)
 
-  fun tag _parse_single_request(obj: JsonObject): (Request val | ParseError) =>
+  fun tag _parse_single_request(obj: JsonObject): (Request | ParseError) =>
     // verify "jsonrpc": "2.0"
     try
       let protocol = obj.data("jsonrpc")? as String

--- a/jsonrpc/response.pony
+++ b/jsonrpc/response.pony
@@ -1,7 +1,7 @@
 use "json"
 use "collections"
 
-class Response  
+class Response
   let method : String
   let result : JsonType
   let id : RequestIDType
@@ -15,21 +15,21 @@ class Response
 
   fun ref to_json(): String =>
     let doc:JsonDoc = JsonDoc
-    
+
     var dmap: Map[String, JsonType] = Map[String, JsonType]
-    dmap("jsonrpc") = "2.0"      
+    dmap("jsonrpc") = Protocol.version()
     dmap("id") = id
-    
+
     match err
     | let e: Error val => dmap("error") = e.to_jsonobject()
-    else    
-      if result isnt None then        
+    else
+      if result isnt None then
         dmap("result") = result
-      end 
-    end 
-    
-    let obj:JsonObject = JsonObject.from_map(dmap)
+      end
+    end
+
+    let obj: JsonObject = JsonObject.from_map(dmap)
     doc.data = obj
-    doc.string("", false)
+    doc.string()
 
 

--- a/jsonrpc/response.pony
+++ b/jsonrpc/response.pony
@@ -16,9 +16,7 @@ class val Response
     result = result'
     err = None
 
-  fun box to_json(): String =>
-    let doc: JsonDoc = JsonDoc
-
+  fun box to_jsonobject(): JsonObject =>
     var dmap: Map[String, JsonType] trn = recover Map[String, JsonType] end
     dmap("jsonrpc") = Protocol.version()
     dmap("id") = id
@@ -30,9 +28,12 @@ class val Response
         dmap("result") = result
       end
     end
+    JsonObject(consume dmap)
 
-    let obj: JsonObject = JsonObject(consume dmap)
-    doc.data = obj
+  fun box to_json(): String =>
+    let doc: JsonDoc = JsonDoc
+
+    doc.data = to_jsonobject()
     doc.string()
 
 

--- a/jsonrpc/response.pony
+++ b/jsonrpc/response.pony
@@ -1,25 +1,25 @@
-use "json"
+use "immutable-json"
 use "collections"
 
-class Response
-  let result : JsonType
+class val Response
+  let result : JsonType val
   let id : RequestIDType
   let err : (Error val | None)
 
-  new error(id': RequestIdType. err': Error val) =>
+  new val from_error(id': RequestIDType, err': Error val) =>
     id = id'
     result = None
     err = err'
 
-  new success(id': RequestIDType, result': JsonType val) =>
+  new val success(id': RequestIDType, result': JsonType val) =>
     id = id'
     result = result'
     err = None
 
-  fun ref to_json(): String =>
-    let doc:JsonDoc = JsonDoc
+  fun box to_json(): String =>
+    let doc: JsonDoc = JsonDoc
 
-    var dmap: Map[String, JsonType] = Map[String, JsonType]
+    var dmap: Map[String, JsonType] trn = recover Map[String, JsonType] end
     dmap("jsonrpc") = Protocol.version()
     dmap("id") = id
 
@@ -31,7 +31,7 @@ class Response
       end
     end
 
-    let obj: JsonObject = JsonObject.from_map(dmap)
+    let obj: JsonObject = JsonObject(consume dmap)
     doc.data = obj
     doc.string()
 

--- a/jsonrpc/response.pony
+++ b/jsonrpc/response.pony
@@ -2,16 +2,19 @@ use "json"
 use "collections"
 
 class Response
-  let method : String
   let result : JsonType
   let id : RequestIDType
   let err : (Error val | None)
 
-  new create(method': String, result': JsonType, id': RequestIDType, err' : (Error val| None) = None) =>
-    method = method'
-    result = result'
+  new error(id': RequestIdType. err': Error val) =>
     id = id'
+    result = None
     err = err'
+
+  new success(id': RequestIDType, result': JsonType val) =>
+    id = id'
+    result = result'
+    err = None
 
   fun ref to_json(): String =>
     let doc:JsonDoc = JsonDoc

--- a/jsonrpc/test/_test_dispatcher.pony
+++ b/jsonrpc/test/_test_dispatcher.pony
@@ -1,7 +1,7 @@
 use "ponytest"
 use "collections"
 use "promises"
-use "json"
+use "immutable-json"
 
 use ".."
 
@@ -35,11 +35,11 @@ actor _HelloWorld is MethodHandler
   be handle(request: Request val, p: Promise[Response val]) =>
     let name: String =
       try
-        (request.params as JsonArray val).data(0)? as String
+        (request.params as JsonArray).data(0)? as String
       else
         "world!"
       end
     let greet: String = "hello " + name
 
-    let r: Response val = recover val Response(request.method, greet, request.id) end
+    let r: Response val = Response.success(request.id, greet)
     p(r)

--- a/jsonrpc/test/_test_dispatcher.pony
+++ b/jsonrpc/test/_test_dispatcher.pony
@@ -11,34 +11,35 @@ class iso _TestDispatchGreet is UnitTest
   """
   fun name(): String => "JSONRPC/dispatcher/greet"
 
-  fun apply(h: TestHelper) ? =>          
+  fun apply(h: TestHelper) ? =>
     h.long_test(30000)
-    let src = 
+    let src =
       """
-      {"jsonrpc": "2.0", "method": "greet", "params": "bob", "id": 1}
+      {"jsonrpc": "2.0", "method": "greet", "params": ["bob"], "id": 1}
       """
-    let request= RequestParser.parse_request(src)?
+    let request= RequestParser.parse_request(src) as Request val
     let handler = _HelloWorld
-    let dispatcher = Dispatcher 
+    let dispatcher = Dispatcher
     dispatcher.register_handler("greet", handler)
 
     let p = Promise[Response val]
-    p.next[None]( {(r:Response val): None ? => 
+    p.next[None]( {(r:Response val): None ? =>
                     h.assert_eq[String]("hello bob", r.result as String)
                     h.complete(true) } iso,
-                  {(): None =>                     
+                  {(): None =>
                     h.complete(false) } iso)
-       
-    dispatcher.dispatch_request(request, p) 
+
+    dispatcher.dispatch_request(request, p)
 
 actor _HelloWorld is MethodHandler
-  be handle(request: Request val, p: Promise[Response val]) =>  
-    let name: String = match request.params
-    | let s: String => s
-    else
-      "world!"
-    end
-    let greet: String = "hello " + name 
+  be handle(request: Request val, p: Promise[Response val]) =>
+    let name: String =
+      try
+        (request.params as JsonArray val).data(0)? as String
+      else
+        "world!"
+      end
+    let greet: String = "hello " + name
 
     let r: Response val = recover val Response(request.method, greet, request.id) end
     p(r)

--- a/jsonrpc/test/_test_parser.pony
+++ b/jsonrpc/test/_test_parser.pony
@@ -1,8 +1,23 @@
 use "ponytest"
 use "collections"
-use "json"
+use "immutable-json"
 
 use ".."
+
+primitive ParserTests is TestList
+  fun tag tests(test: PonyTest) =>
+    test(_TestBadMethod)
+    test(_TestParseBadJSON)
+    test(_TestParseRequestNoId)
+    test(_TestParseRequestNoParams)
+    test(_TestParseRequestArrayParams)
+    test(_TestParseRequestObjectParams)
+    test(_TestParseRequestBadParams)
+    test(_TestParseRequestBatch)
+    test(_TestParseRequestBatchInvalidJson)
+    test(_TestParseRequestBatchEmpty)
+    test(_TestParseRequestBatchInvalid)
+    test(_TestParseRequestBatchSomeInvalid)
 
 class iso _TestBadMethod is UnitTest
   """
@@ -50,7 +65,7 @@ class iso _TestParseRequestNoId is UnitTest
     let request = RequestParser.parse_request(src) as Request val
     h.assert_true(request.is_notification())
     h.assert_eq[String]("foobar", request.method)
-    let array = request.params as JsonArray val
+    let array = request.params as JsonArray
     h.assert_eq[USize](2, array.data.size())
     h.assert_eq[I64](42, array.data(0)? as I64)
     h.assert_eq[I64](23, array.data(1)? as I64)
@@ -95,7 +110,7 @@ class iso _TestParseRequestArrayParams is UnitTest
       h.fail("Shouldn't get a none")
     end
 
-    let array = request.params as JsonArray val
+    let array = request.params as JsonArray
     h.assert_eq[USize](2, array.data.size())
     h.assert_eq[I64](42, array.data(0)? as I64)
     h.assert_eq[I64](23, array.data(1)? as I64)
@@ -122,7 +137,153 @@ class iso _TestParseRequestObjectParams is UnitTest
       h.fail("Shouldn't get a none")
     end
 
-    let params = request.params as JsonObject val
+    let params = request.params as JsonObject
     h.assert_eq[USize](2, params.data.size())
     h.assert_eq[I64](23, params.data("subtrahend")? as I64)
     h.assert_eq[I64](42, params.data("minuend")? as I64)
+
+class iso _TestParseRequestBadParams is UnitTest
+  fun name(): String => "JSONRPC/parserequest/bad-params"
+  fun apply(h: TestHelper) =>
+    let src = """
+     {"jsonrpc":"2.0", "method": "bad-params", "params": true, "id":1}
+    """
+    match RequestParser.parse_request(src)
+    | InvalidRequest => h.log("Bad Params identified as invalid, all good.")
+    else
+      h.fail("Bad Params not detected as invalid, all bad.")
+    end
+
+class iso _TestParseRequestBatch is UnitTest
+  """
+  Test parsing of JSON-RPC 2.0 batch requests: https://www.jsonrpc.org/specification#batch
+  """
+  fun name(): String => "JSONRPC/parserequest/batch"
+
+  fun apply(h: TestHelper) ? =>
+    let src = """
+    [
+        {"jsonrpc": "2.0", "method": "notify_sum", "params": [1,2,4]},
+        {"jsonrpc": "2.0", "method": "notify_hello", "params": [7]}
+    ]
+    """
+    match RequestParser.parse_request(src)
+    | let batch: BatchRequest =>
+      h.assert_eq[USize](2, batch.size())
+
+      let req1 = batch(0)? as Request val
+      h.assert_true(req1.is_notification())
+      h.assert_eq[String]("notify_sum", req1.method)
+      let params = req1.params as JsonArray
+      h.assert_eq[USize](3, params.data.size())
+      h.assert_eq[I64](1, params.data(0)? as I64)
+      h.assert_eq[I64](2, params.data(1)? as I64)
+      h.assert_eq[I64](4, params.data(2)? as I64)
+
+      let req2 = batch(1)? as Request val
+      h.assert_true(req2.is_notification())
+      h.assert_eq[String]("notify_hello", req2.method)
+      let params2 = req2.params as JsonArray
+      h.assert_eq[USize](1, params2.data.size())
+      h.assert_eq[I64](7, params2.data(0)? as I64)
+
+    else
+      h.fail("batch request not parsed to Array")
+    end
+
+class iso _TestParseRequestBatchInvalidJson is UnitTest
+  fun name(): String => "JSONRPC/parserequest/batch-invalid-json"
+
+  fun apply(h: TestHelper) =>
+    let src = """
+      [
+        {"jsonrpc": "2.0", "method": "sum", "params": [1,2,4], "id": "1"},
+        {"jsonrpc": "2.0", "method"
+      ]
+    """
+    h.assert_is[ParseResult](
+      InvalidJson,
+      RequestParser.parse_request(src))
+
+
+class iso _TestParseRequestBatchEmpty is UnitTest
+  fun name(): String => "JSONRPC/parserequest/batch-empty"
+
+  fun apply(h: TestHelper) =>
+    let src = "[]"
+    h.assert_is[ParseResult](
+      InvalidRequest,
+      RequestParser.parse_request(src))
+
+class iso _TestParseRequestBatchInvalid is UnitTest
+  fun name(): String => "JSONRPC/parserequest/batch-invalid"
+
+  fun apply(h: TestHelper) ? =>
+    let src = "[1,2,3]"
+    match RequestParser.parse_request(src)
+    | let br: BatchRequest =>
+      h.assert_eq[USize](3, br.size())
+      h.assert_is[(Request val | ParseError)](
+        InvalidRequest,
+        br(0)?)
+      h.assert_is[(Request val | ParseError)](
+        InvalidRequest,
+        br(1)?)
+      h.assert_is[(Request val | ParseError)](
+        InvalidRequest,
+        br(2)?)
+    else
+      h.fail("Invalid batch request not recognized as such.")
+    end
+
+class iso _TestParseRequestBatchSomeInvalid is UnitTest
+  fun name(): String => "JSONRPC/parserequest/batch-some-invalid"
+
+  fun apply(h: TestHelper) ? =>
+    let src = """
+    [
+        {"jsonrpc": "2.0", "method": "sum", "params": [1,2,4], "id": "1"},
+        {"jsonrpc": "2.0", "method": "notify_hello", "params": [7]},
+        {"jsonrpc": "2.0", "method": "subtract", "params": [42,23], "id": "2"},
+        {"foo": "boo"},
+        {"jsonrpc": "2.0", "method": "foo.get", "params": {"name": "myself"}, "id": "5"},
+        {"jsonrpc": "2.0", "method": "get_data", "id": "9"}
+    ]
+    """
+    match RequestParser.parse_request(src)
+    | let br: BatchRequest =>
+      h.assert_eq[USize](6, br.size())
+
+      let req1 = br(0)? as Request val
+      h.assert_eq[String](req1.id as String, "1")
+      h.assert_false(req1.is_notification())
+      h.assert_eq[String](req1.method, "sum")
+
+      let req2 = br(1)? as Request val
+      h.assert_true(req2.is_notification())
+      h.assert_is[None](req2.id as None, None)
+      h.assert_eq[String](req2.method, "notify_hello")
+
+      let req3 = br(2)? as Request val
+      h.assert_eq[String](req3.id as String, "2")
+      h.assert_false(req3.is_notification())
+      h.assert_eq[String](req3.method, "subtract")
+
+      h.assert_is[(Request val | ParseError)](
+        InvalidRequest,
+        br(3)?)
+
+      let req4 = br(4)? as Request val
+      h.assert_eq[String](req4.id as String, "5")
+      h.assert_false(req4.is_notification())
+      h.assert_eq[String](req4.method, "foo.get")
+
+      let req5 = br(5)? as Request val
+      h.assert_eq[String](req5.id as String, "9")
+      h.assert_false(req5.is_notification())
+      h.assert_eq[String](req5.method, "get_data")
+      h.assert_is[RequestParamsType](req5.params, None)
+    else
+      h.fail("Batch request with some invalid entries not recognized as such")
+    end
+

--- a/jsonrpc/test/_test_response.pony
+++ b/jsonrpc/test/_test_response.pony
@@ -1,65 +1,63 @@
 use "ponytest"
 use "collections"
-use "json"
+use "immutable-json"
 
 use ".."
 
 class iso _TestResponseScalar is UnitTest
   """
-  Tests that an array response properly converts into JSON 
+  Tests that an array response properly converts into JSON
   """
   fun name(): String => "JSONRPC/parserequest/responsescalar"
 
   fun apply(h: TestHelper) =>
-    let target = 
+    let target =
       """{"jsonrpc":"2.0","id":1,"result":19}"""
-    
-    let resp = Response("subtract", I64(19), I64(1), None)
+
+    let resp = Response.success(where id'=I64(1), result'=I64(19))
     let resp_json = resp.to_json()
     h.assert_eq[String](target,resp_json)
 
   class iso _TestResponseArray is UnitTest
-  """
-  Tests that an array response properly converts into JSON 
-  """
-  fun name(): String => "JSONRPC/parserequest/responsearray"
+    """
+    Tests that an array response properly converts into JSON
+    """
+    fun name(): String => "JSONRPC/parserequest/responsearray"
 
-  fun apply(h: TestHelper) =>
-    let target = 
-      """{"jsonrpc":"2.0","id":6,"result":[1,2,3]}"""
-    let array: JsonArray = JsonArray
-    array.data.push(I64(1))
-    array.data.push(I64(2))
-    array.data.push(I64(3))
-    let resp = Response("subtract", array, I64(6), None)
-    let resp_json = resp.to_json()
-    h.assert_eq[String](target,resp_json)
+    fun apply(h: TestHelper) =>
+      let target =
+        """{"jsonrpc":"2.0","id":6,"result":[1,2,3]}"""
+      let array = JsonArray([I64(1); I64(2); I64(3)])
+
+      let resp = Response.success(I64(6), array)
+      let resp_json = resp.to_json()
+      h.assert_eq[String](target, resp_json)
 
 class iso _TestResponseError is UnitTest
   """
-  Tests that an error response properly converts into JSON 
+  Tests that an error response properly converts into JSON
   """
   fun name(): String => "JSONRPC/parserequest/responseerror"
 
   fun apply(h: TestHelper) =>
-    let target = 
+    let target =
       """{"error":{"message":"Method not found","code":-32601},"jsonrpc":"2.0","id":1}"""
 
-    let resp = Response("bamfiz", None, I64(1), recover val Error(ErrorCodes.method_not_found(), "Method not found", None) end)
+    let resp = Response.from_error(I64(1), Error.method_not_found())
     let resp_json = resp.to_json()
     h.assert_eq[String](target, resp_json)
 
 class iso _TestResponseErrorNoID is UnitTest
   """
-  Tests that an error response properly converts into JSON 
+  Tests that an error response properly converts into JSON
   """
   fun name(): String => "JSONRPC/parserequest/responseerror/noid"
 
   fun apply(h: TestHelper) =>
-    let target = 
+    let target =
       """{"error":{"message":"Invalid Request","code":-32600},"jsonrpc":"2.0","id":null}"""
 
-    let resp = Response("bamfiz", None, None, recover val Error(ErrorCodes.invalid_request(), "Invalid Request", None) end)
+    let resp = Response.from_error(None, Error.invalid_request())
     let resp_json = resp.to_json()
     h.assert_eq[String](target, resp_json)
 

--- a/jsonrpc/test/main.pony
+++ b/jsonrpc/test/main.pony
@@ -5,12 +5,7 @@ actor Main is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>
-    test(_TestParseRequestArrayParams)
-    test(_TestParseRequestObjectParams)
-    test(_TestParseRequestNoId)
-    test(_TestParseRequestNoParams)
-    test(_TestParseBadJSON)
-    test(_TestBadMethod)
+    ParserTests.tests(test)
 
     test(_TestResponseScalar)
     test(_TestResponseArray)


### PR DESCRIPTION
...including Batch Requests.

I swapped the stdlib json package with a modified one, which has everything val: https://github.com/mfelsche/pony-immutable-json The stdlib json package was very nasty because of the JsonArray ref and JsonObject ref. :/

I also removed partial parsing and instead returned primitives describing the particular error. This makes it possible to differentiate between invalid requests and parse errors (invalid json).

If you don't want to merge this, i am fine. Then I continue maintaining this in my fork.

Anyways, big thanks for your initial work! It was a great starting point!